### PR TITLE
feat(component): add new feature post-details to always start at the very top

### DIFF
--- a/angular-primeng-app/src/app/components/post-details/post-details.component.ts
+++ b/angular-primeng-app/src/app/components/post-details/post-details.component.ts
@@ -17,6 +17,7 @@ import { ButtonModule } from "primeng/button";
 import { InputSwitchModule } from "primeng/inputswitch";
 import { SanitizerHtmlPipe } from "../../pipes/sanitizer-html.pipe";
 import { YoutubeVideoEmbedDirective } from "../../directives/youtube-video-embed.directive";
+import { ViewportScroller } from "@angular/common";
 
 @Component({
 	selector: "app-post-details",
@@ -52,10 +53,12 @@ export class PostDetailsComponent implements OnInit, OnDestroy {
 	themeService: ThemeService = inject(ThemeService);
 	private blogService: BlogService = inject(BlogService);
   private querySubscription?: Subscription;
+  private readonly scroller = inject(ViewportScroller);
 
 	@Input({ required: true }) postSlug!: string;
 
   ngOnInit(): void {
+	this.scroller.scrollToPosition([0, 0]);
     this.blogURL = this.blogService.getBlogURL();
 		this.querySubscription = this.blogService
 			.getBlogInfo(this.blogURL)


### PR DESCRIPTION
## This PR Closes Issue closes #
https://github.com/AnguHashBlog/angular-primeng/issues/41

## Description
1. The post details page takes the previous page position instead of the top of the page.
2. used ViewportScroller inside the ngOnInit method.

## What type of PR is this? (check all applicable)

- [x] 🅰️ Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Mobile & Desktop Screenshots/Recordings
[Attach screenshots or recordings if applicable]

## Steps to QA

## Added to documentation?
- [ ] 📜 README.md
- [x] 🙅 no documentation needed

## [Optional] Post-deployment tasks
[Specify any post-deployment tasks that need to be performed]

## [Optional] What gif best describes this PR or how it makes you feel? 
[Embed gif or describe the feeling in plain text]
