### PR TITLE
feat(sitewide): add scroll to top button to conditionally appear in longer pages

### DIFF
--- a/angular-primeng-app/src/app/app.component.html
+++ b/angular-primeng-app/src/app/app.component.html
@@ -3,6 +3,6 @@
   <router-outlet />
 </div>
 <app-footer />
-@if (enableScrollUp) {
-<p-button class="pageUpButton" (click)="goPageTop()" icon="pi pi-angle-up" [rounded]="true" size="small"></p-button>
+@if (showScrollButton) {
+<p-button class="pageUpButton" (click)="scrollToTop()" icon="pi pi-angle-up" [rounded]="true" size="small"></p-button>
 }

--- a/angular-primeng-app/src/app/app.component.html
+++ b/angular-primeng-app/src/app/app.component.html
@@ -3,3 +3,6 @@
   <router-outlet />
 </div>
 <app-footer />
+@if (enableScrollUp) {
+<p-button class="pageUpButton" (click)="goPageTop()" icon="pi pi-angle-up" [rounded]="true" size="small"></p-button>
+}

--- a/angular-primeng-app/src/app/app.component.scss
+++ b/angular-primeng-app/src/app/app.component.scss
@@ -5,3 +5,10 @@
   min-height: 74vh;
   width: 100%;
 }
+
+.pageUpButton {
+  position: fixed;
+  bottom: 10px;
+  right: 14px;
+}
+

--- a/angular-primeng-app/src/app/app.component.ts
+++ b/angular-primeng-app/src/app/app.component.ts
@@ -1,17 +1,18 @@
 import { Component, OnInit, OnDestroy, inject, Inject } from "@angular/core";
 import { RouterOutlet } from "@angular/router";
-import { Subscription } from "rxjs";
+import { Subscription, fromEvent } from "rxjs";
 import { BlogInfo } from "./models/blog-info";
 import { BlogService } from "./services/blog.service";
 import { ThemeService } from "./services/theme.service";
-import { DOCUMENT } from "@angular/common";
+import { DOCUMENT, ViewportScroller } from "@angular/common";
 import { HeaderComponent } from "./components/header/header.component";
 import { FooterComponent } from "./components/footer/footer.component";
+import { ButtonModule } from "primeng/button";
 
 @Component({
 	selector: "app-root",
 	standalone: true,
-	imports: [RouterOutlet, HeaderComponent, FooterComponent],
+	imports: [RouterOutlet, HeaderComponent, FooterComponent,ButtonModule],
 	templateUrl: "./app.component.html",
 	styleUrl: "./app.component.scss",
 })
@@ -23,6 +24,9 @@ export class AppComponent implements OnInit, OnDestroy {
 	themeService: ThemeService = inject(ThemeService);
 	blogService: BlogService = inject(BlogService);
 	private querySubscription?: Subscription;
+	private scrollEvntSub?: Subscription;
+	enableScrollUp: boolean=false;
+	private readonly scroller = inject(ViewportScroller);
 
 	constructor(@Inject(DOCUMENT) private document: Document) {}
 
@@ -50,9 +54,30 @@ export class AppComponent implements OnInit, OnDestroy {
 					});
 				}
 			});
+
+		this.scrollEvntSub = fromEvent(this.document, 'scroll')
+			.subscribe(() => {
+				if (this.calculatePositionScroll() > 50)
+					this.enableScrollUp = true;
+				else
+					this.enableScrollUp = false;
+			})
+	}
+
+	goPageTop() {
+		this.scroller.scrollToPosition([0, 0]);
+	}
+
+	calculatePositionScroll(): number {
+		var scrollTop = this.document.documentElement.scrollTop;
+		var docHeight = this.document.documentElement.scrollHeight;
+		var winHeight = this.document.documentElement.clientHeight;
+		var scrollPercent = (scrollTop) / (docHeight - winHeight);
+		return Math.round(scrollPercent * 100);
 	}
 
 	ngOnDestroy(): void {
+		this.scrollEvntSub?.unsubscribe();
 		this.querySubscription?.unsubscribe();
 	}
 }

--- a/angular-primeng-app/src/app/app.component.ts
+++ b/angular-primeng-app/src/app/app.component.ts
@@ -1,6 +1,6 @@
-import { Component, OnInit, OnDestroy, inject, Inject } from "@angular/core";
+import { Component, OnInit, OnDestroy, inject, Inject, HostListener } from "@angular/core";
 import { RouterOutlet } from "@angular/router";
-import { Subscription, fromEvent } from "rxjs";
+import { Subscription } from "rxjs";
 import { BlogInfo } from "./models/blog-info";
 import { BlogService } from "./services/blog.service";
 import { ThemeService } from "./services/theme.service";
@@ -12,7 +12,7 @@ import { ButtonModule } from "primeng/button";
 @Component({
 	selector: "app-root",
 	standalone: true,
-	imports: [RouterOutlet, HeaderComponent, FooterComponent,ButtonModule],
+	imports: [RouterOutlet, HeaderComponent, FooterComponent, ButtonModule],
 	templateUrl: "./app.component.html",
 	styleUrl: "./app.component.scss",
 })
@@ -24,11 +24,10 @@ export class AppComponent implements OnInit, OnDestroy {
 	themeService: ThemeService = inject(ThemeService);
 	blogService: BlogService = inject(BlogService);
 	private querySubscription?: Subscription;
-	private scrollEvntSub?: Subscription;
-	enableScrollUp: boolean=false;
+	showScrollButton: boolean = false;
 	private readonly scroller = inject(ViewportScroller);
 
-	constructor(@Inject(DOCUMENT) private document: Document) {}
+	constructor(@Inject(DOCUMENT) private document: Document) { }
 
 	ngOnInit(): void {
 		this.blogURL = this.blogService.getBlogURL();
@@ -54,30 +53,23 @@ export class AppComponent implements OnInit, OnDestroy {
 					});
 				}
 			});
-
-		this.scrollEvntSub = fromEvent(this.document, 'scroll')
-			.subscribe(() => {
-				if (this.calculatePositionScroll() > 50)
-					this.enableScrollUp = true;
-				else
-					this.enableScrollUp = false;
-			})
 	}
 
-	goPageTop() {
+	@HostListener('window:scroll', [])
+	onWindowScroll() {
+		const yOffset = window.pageYOffset || document.documentElement.scrollTop;
+		if (yOffset > 300) { 
+			this.showScrollButton = true;
+		} else {
+			this.showScrollButton = false;
+		}
+	}
+
+	scrollToTop() {
 		this.scroller.scrollToPosition([0, 0]);
 	}
 
-	calculatePositionScroll(): number {
-		var scrollTop = this.document.documentElement.scrollTop;
-		var docHeight = this.document.documentElement.scrollHeight;
-		var winHeight = this.document.documentElement.clientHeight;
-		var scrollPercent = (scrollTop) / (docHeight - winHeight);
-		return Math.round(scrollPercent * 100);
-	}
-
 	ngOnDestroy(): void {
-		this.scrollEvntSub?.unsubscribe();
 		this.querySubscription?.unsubscribe();
 	}
 }


### PR DESCRIPTION
## This PR Closes Issue  closes #
https://github.com/AnguHashBlog/angular-primeng/issues/28

## Description
long blog posts there should be a scroll to pop button / icon that returns the user to the beginning of the page
for this app version primeicons used
applied in the app.component 

## What type of PR is this? (check all applicable)

- [x] 🅰️ Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Mobile & Desktop Screenshots/Recordings
[Attach screenshots or recordings if applicable]

## Steps to QA

## Added to documentation?
- [ ] 📜 README.md
- [x] 🙅 no documentation needed

## [Optional] Post-deployment tasks
[Specify any post-deployment tasks that need to be performed]

## [Optional] What gif best describes this PR or how it makes you feel? 
[Embed gif or describe the feeling in plain text]
