### PR TITLE
feat(post-details): author and co-authors to be clickable links leading to the author's page on Hashnode

### DIFF
--- a/angular-primeng-app/src/app/components/post-details/post-details.component.html
+++ b/angular-primeng-app/src/app/components/post-details/post-details.component.html
@@ -7,13 +7,19 @@
         <div class="author-info">
           @if (isTeam) {
             <p-avatarGroup styleClass="mb-3" >
+              <a href="https://hashnode.com/@{{post.author.username}}" target="_blank">
                <p-avatar [image]="post.author.profilePicture" size="large" shape="circle" title="{{ post.author.username}}"></p-avatar>
+               </a>
                @for (coAuthor of post.coAuthors; track coAuthor.username) {
-                 <p-avatar [image]="coAuthor.profilePicture" size="large"  shape="circle" title="{{ coAuthor.username}}"></p-avatar>
+                <a href="https://hashnode.com/@{{coAuthor.username}}" target="_blank">
+                 <p-avatar [image]="coAuthor.profilePicture" size="large"  shape="circle" title="{{coAuthor.username}}"></p-avatar>
+                 </a>
                 }
             </p-avatarGroup>
           } @else {
+            <a href="https://hashnode.com/@{{post.author.username}}" target="_blank">
              <p-avatar [image]="post.author.profilePicture" size="large"  shape="circle" title="{{ post.author.username}}"></p-avatar>
+            </a>
             }
           <div class="author-text">
             <span class="author-name">{{post.author.name}} {{isTeam && post.coAuthors.length > 0 ? 'with ' + post.coAuthors.length + ' co-author' + (post.coAuthors.length > 1 ? 's' : '') : ''}}</span>


### PR DESCRIPTION
…


## This PR Closes Issue 
closes #61 

## Description
I added the anchor tag to the avatar image for the posts' authors and co-authors that will lead to author's profile in Hashnode in another tab 
## What type of PR is this? (check all applicable)

- [x] 🅰️ Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Mobile & Desktop Screenshots/Recordings
[Attach screenshots or recordings if applicable]
the link screenshot : 
![image](https://github.com/AnguHashBlog/angular-primeng/assets/92154267/ed12245d-435d-4e2e-95ce-6055f1e109d7)
![image](https://github.com/AnguHashBlog/angular-primeng/assets/92154267/3296e5ae-8664-4fd0-9bcb-b8998b8b1693)

## Steps to QA

## Added to documentation?
- [ ] 📜 README.md
- [x] 🙅 no documentation needed

## [Optional] Post-deployment tasks
[Specify any post-deployment tasks that need to be performed]

## [Optional] What gif best describes this PR or how it makes you feel? 
[Embed gif or describe the feeling in plain text]
